### PR TITLE
Fix the wrong v0.0.0 version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,4 @@ extra:
     - moorepants
     - seisman
     - weiji14
+    - willschlitzer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: SETUPTOOLS_SCM_PRETEND_VERSION={{ version }} {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -32,6 +32,7 @@ test:
     - pygmt
     - pygmt.tests
   commands:
+    - python -c "import pygmt; assert pygmt.__version__ != 'v0.0.0'"
     - python -c "import pygmt; pygmt.show_versions()"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,9 @@ requirements:
   host:
     - pip
     - python >=3.6
+    - setuptools >=45
+    - setuptools_scm >=3.4
+    - toml
   run:
     - gmt >=6.1.1,<7.0
     - netCDF4


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Problem with setuptools_scm not getting correct version. PR is based on https://github.com/conda-forge/pint-feedstock/pull/34.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
